### PR TITLE
Issue 40: Render issue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -37,9 +37,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  background: var(--background);
+  background-color: var(--background);
   background-attachment: fixed;
-  height: 100vh;
   font-family: "Inter", sans-serif;
 }
 


### PR DESCRIPTION
#40 

Description
---
- Changed background tag to background-color tag and removed height property that is set to be 100% of view to keep the background color consistent all over the page. 
- My guess is, dark-reader does not tweak background tag. 

![image](https://user-images.githubusercontent.com/35599492/177015031-b563b557-0645-47d5-aeb6-24b9cbca17ba.png)

